### PR TITLE
impl radiation bc for stationary thermal problem, added ut

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(finite_elements)
 add_subdirectory(math_expression_tests)
 add_subdirectory(nonstationary_thermal_1d)
 add_subdirectory(parallel)
+add_subdirectory(stationary_thermal_1d)
 
 
 add_executable(unit_tests nonlocal_tests.cpp)
@@ -18,6 +19,7 @@ target_link_libraries(unit_tests
     parallel_test_lib
     config_test_lib
     nonstationary_thermal_1d_lib
+	stationary_thermal_1d_lib
     math_expression_test_lib
 )
 

--- a/tests/math_expression_tests/math_expression_test.cpp
+++ b/tests/math_expression_tests/math_expression_test.cpp
@@ -177,6 +177,12 @@ const suite<"formula"> _ = [] {
         expect(test.to_polish() == "xycos*texp/10+");
         expect(test.variables_count() == 3);
         expect(std::abs(test({ 2., pi, 10. }) - 9.99991) < 1e-6);
+
+        test = math_expression("x y : 400.0 * exp((x - 1.0)^2 * -400.0 )");
+        expect(test.variables_count() == 2);
+        expect(std::abs(test({ 1., 100. }) - 400.) < 1e-6);
+        std::cout << test({ 1.13, 100. }) << std::endl;
+        expect(std::abs(test({ 1.13, 100. }) - 0.463692) < 1e-6);
     };
 
     "polish_notation_throws"_test = [] {

--- a/tests/nonstationary_thermal_1d/boundary_conditions_1d.cpp
+++ b/tests/nonstationary_thermal_1d/boundary_conditions_1d.cpp
@@ -246,42 +246,6 @@ const suite<"thermal_nonstationary_boundary_conditions_1d"> _ = [] {
         solve_nonstationary_thermal_1d_problem<flux_1d,        temperature_1d, T, I>(mesh, time, parameters, init_dist, right_part, 
                                                                                      left_flux, right_temp, ref_sol, 1e-2, true);
     };
-
-    // "ref_radiation"_test = [] {
-    //     // Radiation boundary condition
-    //     // d/dx(k dT/dx) = qv
-    //     // qv(x) = 4 * er * sigma * (-3(x - 2))^(-4/3)
-    //     // T|x=0 = 6^(-1/3), q*n|x=1 = -er * sigma * T^4,
-    //     // Exact solution : T(x) = (-3(x - 2))^(-1/3)
-    //     constexpr T emissivity = T(1.0 / 5.67036713e-8);
-    //     constexpr T left_temperature = T(std::pow(6.0, -1./3.));
-    //     const auto left_bc =  [&left_temperature] (const T t) constexpr noexcept { return left_temperature; };
-    //     const auto right_bc = [&emissivity](const T t) constexpr noexcept { return emissivity; };
-    //     constexpr auto ref_sol = [](T t, T x) constexpr noexcept {
-    //         return std::pow(-3. * (x - 2.), -1./3.);
-    //     };
-
-    //     const std::vector<mesh::segment_data<T>> segments({{ .length = T(1.0), .search_radius = T(0.0), .elements = I(100) }});
-
-    //     parameters_1d<T> parameters(segments.size());
-    //     parameters[0] = { .model = { .influence = influence::polynomial_1d<T, 1, 1>{T(0.0)}, .local_weight = T(1.0) },
-    //                                  // conductivity, capacity, density, relaxation_time
-    //                                  .physical = std::make_shared<parameter_1d<T, coefficients_t::CONSTANTS>>
-    //                                  (T(1.0), T(1.0), T(1.0), T(0.0)) };
-        
-    //     const auto mesh = std::make_shared<mesh::mesh_1d<T>>(std::make_unique<element_1d<T>>(quadrature<T>()), segments);
-
-    //     constexpr auto init_dist  = [](const T x)            constexpr noexcept { return T(0.0); };
-    //     constexpr auto right_part = [](const T t, const T x) constexpr noexcept { 
-    //         return 4. * std::pow((-3. * (x - 2.)), -7./3.); 
-    //     };
-        
-    //     const time_data<T> time ({.time_step = T(0.001), .initial_time = T(0.0), .steps_count =  I(1) });
-
-    //     solve_nonstationary_thermal_1d_problem<radiation_1d, radiation_1d, T, I>(mesh, time, parameters, init_dist, right_part, 
-    //                                                                              left_bc, right_bc, ref_sol, 1e-8);
-
-    // };
 };
     
 }

--- a/tests/nonstationary_thermal_1d/boundary_conditions_1d.cpp
+++ b/tests/nonstationary_thermal_1d/boundary_conditions_1d.cpp
@@ -28,7 +28,9 @@ void check_solution(const std::shared_ptr<mesh::mesh_1d<T>>& mesh, const heat_eq
                     std::function<T(T, T)> ref, T eps = T{1e-8}) {
     auto& sol = solution.temperature();
     for (std::size_t k = 0; k < sol.size(); ++k) {
-        expect(lt(std::abs(sol[k] - ref(time_layer, mesh->node_coord(k))), eps * step));
+        const T ref_val = ref(time_layer, mesh->node_coord(k));
+        const T err = ref_val > 0 ? (sol[k] - ref_val) / ref_val : sol[k] - ref_val;     
+        expect(lt(std::abs(err), eps * step));
     }
 }
 
@@ -244,6 +246,42 @@ const suite<"thermal_nonstationary_boundary_conditions_1d"> _ = [] {
         solve_nonstationary_thermal_1d_problem<flux_1d,        temperature_1d, T, I>(mesh, time, parameters, init_dist, right_part, 
                                                                                      left_flux, right_temp, ref_sol, 1e-2, true);
     };
+
+    // "ref_radiation"_test = [] {
+    //     // Radiation boundary condition
+    //     // d/dx(k dT/dx) = qv
+    //     // qv(x) = 4 * er * sigma * (-3(x - 2))^(-4/3)
+    //     // T|x=0 = 6^(-1/3), q*n|x=1 = -er * sigma * T^4,
+    //     // Exact solution : T(x) = (-3(x - 2))^(-1/3)
+    //     constexpr T emissivity = T(1.0 / 5.67036713e-8);
+    //     constexpr T left_temperature = T(std::pow(6.0, -1./3.));
+    //     const auto left_bc =  [&left_temperature] (const T t) constexpr noexcept { return left_temperature; };
+    //     const auto right_bc = [&emissivity](const T t) constexpr noexcept { return emissivity; };
+    //     constexpr auto ref_sol = [](T t, T x) constexpr noexcept {
+    //         return std::pow(-3. * (x - 2.), -1./3.);
+    //     };
+
+    //     const std::vector<mesh::segment_data<T>> segments({{ .length = T(1.0), .search_radius = T(0.0), .elements = I(100) }});
+
+    //     parameters_1d<T> parameters(segments.size());
+    //     parameters[0] = { .model = { .influence = influence::polynomial_1d<T, 1, 1>{T(0.0)}, .local_weight = T(1.0) },
+    //                                  // conductivity, capacity, density, relaxation_time
+    //                                  .physical = std::make_shared<parameter_1d<T, coefficients_t::CONSTANTS>>
+    //                                  (T(1.0), T(1.0), T(1.0), T(0.0)) };
+        
+    //     const auto mesh = std::make_shared<mesh::mesh_1d<T>>(std::make_unique<element_1d<T>>(quadrature<T>()), segments);
+
+    //     constexpr auto init_dist  = [](const T x)            constexpr noexcept { return T(0.0); };
+    //     constexpr auto right_part = [](const T t, const T x) constexpr noexcept { 
+    //         return 4. * std::pow((-3. * (x - 2.)), -7./3.); 
+    //     };
+        
+    //     const time_data<T> time ({.time_step = T(0.001), .initial_time = T(0.0), .steps_count =  I(1) });
+
+    //     solve_nonstationary_thermal_1d_problem<radiation_1d, radiation_1d, T, I>(mesh, time, parameters, init_dist, right_part, 
+    //                                                                              left_bc, right_bc, ref_sol, 1e-8);
+
+    // };
 };
     
 }

--- a/tests/stationary_thermal_1d/CMakeLists.txt
+++ b/tests/stationary_thermal_1d/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(stationary_thermal_1d)
+
+set(INCLUDES $ENV{CPATH})
+if (NOT DEFINED NO_CONAN)
+    set(INCLUDES ${CONAN_INCLUDE_DIRS_BOOST-EXT-UT})
+endif()
+
+add_library(stationary_thermal_1d_lib OBJECT boundary_conditions_1d.cpp)
+target_include_directories(stationary_thermal_1d_lib PUBLIC
+    ${LIBRARIES_DIR}
+    ${INCLUDES}
+)
+
+target_link_libraries(stationary_thermal_1d_lib
+    finite_element_solver_1d_lib
+    heat_equation_solver_1d_lib
+)

--- a/tests/stationary_thermal_1d/boundary_conditions_1d.cpp
+++ b/tests/stationary_thermal_1d/boundary_conditions_1d.cpp
@@ -1,0 +1,145 @@
+#include <metamath/metamath.hpp>
+#include <solvers/solver_1d/influence_functions_1d.hpp>
+#include <solvers/solver_1d/thermal/stationary_heat_equation_solver_1d.hpp>
+
+#include <boost/ut.hpp>
+
+namespace {
+
+using namespace boost::ut;
+using namespace nonlocal;
+using namespace nonlocal::thermal;
+
+template<class T>
+using quadrature = metamath::finite_element::quadrature_1d<T, metamath::finite_element::gauss, std::size_t(1)>;
+template<class T>
+using element_1d = metamath::finite_element::element_1d_integrate<T, metamath::finite_element::lagrangian_element_1d, std::size_t(1)>;
+
+template<std::floating_point T>
+void check_solution(const std::shared_ptr<mesh::mesh_1d<T>>& mesh, const heat_equation_solution_1d<T>& solution,
+                    std::function<T(T)> ref, T eps = T{1e-8}) {
+    auto& sol = solution.temperature();
+    T err = 0.0, ref_norm = 0.0;
+    for (std::size_t k = 0; k < sol.size(); ++k) {
+        const T ref_val = ref(mesh->node_coord(k));
+        err += std::pow(sol[k] - ref_val, 2);
+        ref_norm += std::pow(ref_val, 2);
+        //expect(lt(err, eps));
+    }
+    expect(lt(err / ref_norm, eps));
+}
+
+const suite<"thermal_stationary_boundary_conditions_1d"> _ = [] {
+
+    using T = double;
+    using I = int64_t;
+
+    "const_temperature_temperature"_test = [] {
+        // Temperature boundary condition
+        // d/dx(k dT/dx) + qv = 0
+        // qv(x) = -4 * er * sigma * (-3(x - 2))^(-7/3)
+        // T|x=0 = 6^(-1/3), T|x=1 = 3^(-1/3),
+        // Exact solution : T(x) = (-3(x - 2))^(-1/3)
+        constexpr auto ref_sol = [](T x) constexpr noexcept -> T {
+            return std::pow(-3. * (x - 2.), -1./3.);
+        };
+        constexpr T left_temperature = ref_sol(0.0);
+        constexpr T right_temperature = ref_sol(1.0);
+        const thermal_boundaries_conditions_1d<T> boundaries_conditions = {
+            std::make_unique<thermal::temperature_1d<T>>(left_temperature),
+            std::make_unique<thermal::temperature_1d<T>>(right_temperature)
+        };
+        const std::vector<mesh::segment_data<T>> segments({{ .length = T(1.0), .search_radius = T(0.0), .elements = I(10) }});
+        parameters_1d<T> parameters(segments.size());
+        parameters[0] = { .model = { .influence = influence::polynomial_1d<T, 1, 1>{T(0.0)}, .local_weight = T(1.0) },
+                                     // conductivity, capacity, density, relaxation_time
+                                     .physical = std::make_shared<parameter_1d<T, coefficients_t::CONSTANTS>>
+                                     (T(1.0), T(1.0), T(1.0), T(0.0)) };    
+        const auto mesh = std::make_shared<mesh::mesh_1d<T>>(std::make_unique<element_1d<T>>(quadrature<T>()), segments);
+        const stationary_equation_parameters_1d<T> additional_parameters {
+            .right_part = [](const T x) constexpr noexcept {  return -4. * std::pow(-3. * (x - 2.), -7./3.); },
+            .initial_distribution = [](const T x) constexpr noexcept { return 0.0; },
+            .tolerance = std::is_same_v<T, float> ? 1e-6 : 1e-15,
+            .max_iterations = 200,
+            .energy = T{0}
+        };
+        const auto num_sol = stationary_heat_equation_solver_1d<T, I>(mesh, parameters, boundaries_conditions, additional_parameters);
+        check_solution<T>(mesh, num_sol, ref_sol, 1e-8);
+    };
+
+    "const_temperature_radiation"_test = [] {
+        // Radiation boundary condition
+        // d/dx(lambda * dT/dx) + qv = 0
+        // alpha = er * sigma / lambda
+        // qv(x) = -4 * lambda * alpha * alpha * (-3 * alpha * (x - 1.01))^(-7/3)
+        // T|x=0 = T_ref(0), q*n|x=L = er * sigma * T^4,
+        // Exact solution : T_ref(x) = (-3 * alpha * (x - 1.01))^(-1/3)
+        constexpr T sigma = STEFAN_BOLTZMANN_CONSTANT<T>;
+        constexpr T lambda = 10.;
+        constexpr T emissivity =  0.7;
+        constexpr T alpha = emissivity * sigma / lambda;
+        const auto ref_sol = [&](T x) constexpr noexcept -> T {
+            return std::pow(-3. * alpha * (x - 1.01), -1./3.);
+        };
+        constexpr T left_temperature = ref_sol(0.0);
+        const thermal_boundaries_conditions_1d<T> boundaries_conditions = {
+            std::make_unique<thermal::temperature_1d<T>>(left_temperature),
+            std::make_unique<thermal::radiation_1d<T>>(emissivity)
+        };
+        const std::vector<mesh::segment_data<T>> segments({{ .length = T(1.0), .search_radius = T(0.0), .elements = I(1000) }});
+        parameters_1d<T> parameters(segments.size());
+        parameters[0] = { .model = { .influence = influence::polynomial_1d<T, 1, 1>{T(0.0)}, .local_weight = T(1.0) },
+                                     // conductivity, capacity, density, relaxation_time
+                                     .physical = std::make_shared<parameter_1d<T, coefficients_t::CONSTANTS>>
+                                     (lambda, T(1.0), T(1.0), T(0.0)) };    
+        const auto mesh = std::make_shared<mesh::mesh_1d<T>>(std::make_unique<element_1d<T>>(quadrature<T>()), segments);
+        const stationary_equation_parameters_1d<T> additional_parameters {
+            .right_part = [&](const T x) constexpr noexcept {  return -4. * lambda * alpha * alpha * std::pow(-3. * alpha * (x - 1.01), -7./3.); },
+            .initial_distribution = [ref_sol](const T x) constexpr noexcept { return ref_sol(1.0); },
+            .tolerance = std::is_same_v<T, float> ? 1e-5 : 1e-8,
+            .max_iterations = 10,
+            .energy = T{0}
+        };
+        const auto num_sol = stationary_heat_equation_solver_1d<T, I>(mesh, parameters, boundaries_conditions, additional_parameters);
+        check_solution<T>(mesh, num_sol, ref_sol, 1e-6);
+    };
+
+    "const_radiation_temperature"_test = [] {
+        // Radiation boundary condition
+        // d/dx(lambda * dT/dx) + qv = 0
+        // alpha = er * sigma / lambda
+        // qv(x) = -4 * lambda * alpha * alpha * (3 * alpha * (x - 1.01))^(-7/3)
+        // q*n|x=0 = = er * sigma * T^4, T|x=L = T_ref(L),
+        // Exact solution : T_ref(x) = (3 * alpha * (x - 1.01))^(-1/3)
+        constexpr T sigma = STEFAN_BOLTZMANN_CONSTANT<T>;
+        constexpr T lambda = 10.;
+        constexpr T emissivity = 0.7;
+        constexpr T alpha = emissivity * sigma / lambda;
+        const auto ref_sol = [&](T x) constexpr noexcept -> T {
+            return std::pow( T(3.0) * alpha * (x + T(1.01)), T(-1./3.) );
+        };
+        constexpr T right_temperature = ref_sol(1.0);
+        const thermal_boundaries_conditions_1d<T> boundaries_conditions = {
+            std::make_unique<thermal::radiation_1d<T>>(emissivity),
+            std::make_unique<thermal::temperature_1d<T>>(right_temperature)
+        };
+        const std::vector<mesh::segment_data<T>> segments({{ .length = T(1.0), .search_radius = T(0.0), .elements = I(1000) }});
+        parameters_1d<T> parameters(segments.size());
+        parameters[0] = { .model = { .influence = influence::polynomial_1d<T, 1, 1>{T(0.0)}, .local_weight = T(1.0) },
+                                     // conductivity, capacity, density, relaxation_time
+                                     .physical = std::make_shared<parameter_1d<T, coefficients_t::CONSTANTS>>
+                                     (lambda, T(1.0), T(1.0), T(0.0)) };    
+        const auto mesh = std::make_shared<mesh::mesh_1d<T>>(std::make_unique<element_1d<T>>(quadrature<T>()), segments);
+        const stationary_equation_parameters_1d<T> additional_parameters {
+            .right_part = [&](const T x) constexpr noexcept {  return -4. * lambda * alpha * alpha * std::pow(3. * alpha * (x + 1.01), -7./3.); },
+            .initial_distribution = [ref_sol](const T x) constexpr noexcept { return ref_sol(0.0) + 1.; },
+            .tolerance = std::is_same_v<T, float> ? 1e-5 : 1e-8,
+            .max_iterations = 10,
+            .energy = T{0}
+        };
+        const auto num_sol = stationary_heat_equation_solver_1d<T, I>(mesh, parameters, boundaries_conditions, additional_parameters);
+        check_solution<T>(mesh, num_sol, ref_sol, 1e-6);
+    };
+};
+    
+}


### PR DESCRIPTION
Добавил для 1d стационарной задачи теплопроводности граничное условие излучения. Оно считается методом Ньютона. На данный момент он реализован через корректировку невязки, для которой решается задача F'(xk) dx = F(xk), где F(xk) = A * xk - b --- невязка, затем считается следующее решение xk+1 = xk - dx. Я отладил это для тестовых задач, которые добавил в юнит тесты. Логика усложнилась, так как мы решаем для задачи излучения нелинейность Ньютоном, а для зависящей от температуры теплопроводности - простой итерацией. Это надо будет обсудить, как лучше сделать. Возможно стоит явно написать метод Ньютона без упрощений, тогда он будет применим для любого вида нелинейности. 